### PR TITLE
Add support url with params

### DIFF
--- a/src/dope.js
+++ b/src/dope.js
@@ -13,7 +13,7 @@
     var list = [], queue;
     (deps && deps.constructor !== Array && (deps = [deps]), deps.reverse());
     for (var i = queue = deps.length - 1; i >= 0; i--) {
-      var el, type = deps[i].substr((~-deps[i].lastIndexOf('.') >>> 0) + 2).toLowerCase();
+      var el, type = deps[i].split('?')[0].substr((~-deps[i].lastIndexOf('.') >>> 0) + 2).toLowerCase();
       switch(type) {
       case 'js':
         el = document.createElement('script');


### PR DESCRIPTION
This small fix allow to process url with params like 'lorem/ipsum?v=1'. It is useful when you want to prevent caching for targeted files
